### PR TITLE
fix: Support repository's new zip folder structure & private repo

### DIFF
--- a/.changeset/clean-files-learn.md
+++ b/.changeset/clean-files-learn.md
@@ -2,4 +2,4 @@
 '@protocol.land/sync': patch
 ---
 
-Support repository's new zip folder structure
+Support repository's new zip folder structure & private repo

--- a/.changeset/clean-files-learn.md
+++ b/.changeset/clean-files-learn.md
@@ -1,0 +1,5 @@
+---
+'@protocol.land/sync': patch
+---
+
+Support repository's new zip folder structure

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { zipRepoJsZip } from './lib/zipHelper';
 import { uploadRepo } from './lib/arweaveHelper';
 import { getRepos, postRepoToWarp } from './lib/warpHelper';
 import { exitWithError, getTags, getTitle } from './lib/common';
+import { v4 as uuidv4 } from 'uuid';
 
 // Set up constants
 const PATH = '.';
@@ -31,10 +32,12 @@ async function main() {
         (r) => r.name.toLowerCase() === title.toLowerCase()
     );
 
+    const repoId = repoInfo?.id || uuidv4();
+
     // compress the repo
     let zipBuffer;
     try {
-        zipBuffer = await zipRepoJsZip(title, PATH, FOLDER_TO_ZIP);
+        zipBuffer = await zipRepoJsZip(repoId, PATH, FOLDER_TO_ZIP);
     } catch (error) {
         console.error('Error zipping repository:', error);
         process.exit(1);
@@ -45,7 +48,7 @@ async function main() {
     try {
         const dataTxId = await uploadRepo(zipBuffer, tags);
 
-        if (dataTxId) await postRepoToWarp(dataTxId, repoInfo);
+        if (dataTxId) await postRepoToWarp(dataTxId, repoId, repoInfo);
     } catch (error) {
         exitWithError(error as string);
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import { uploadRepo } from './lib/arweaveHelper';
 import { getRepos, postRepoToWarp } from './lib/warpHelper';
 import { exitWithError, getTags, getTitle } from './lib/common';
 import { v4 as uuidv4 } from 'uuid';
+import { encryptRepo } from './lib/privateRepo';
 
 // Set up constants
 const PATH = '.';
@@ -46,6 +47,13 @@ async function main() {
     const tags = await getTags(!repoInfo ? true : false);
 
     try {
+        const isPrivate = repoInfo?.private || false;
+        const privateStateTxId = repoInfo?.privateStateTxId;
+
+        if (isPrivate && privateStateTxId) {
+            zipBuffer = await encryptRepo(zipBuffer, privateStateTxId);
+        }
+
         const dataTxId = await uploadRepo(zipBuffer, tags);
 
         if (dataTxId) await postRepoToWarp(dataTxId, repoId, repoInfo);

--- a/src/lib/arweaveHelper.ts
+++ b/src/lib/arweaveHelper.ts
@@ -9,6 +9,11 @@ export async function getAddress() {
     return await initArweave().wallets.jwkToAddress(getWallet());
 }
 
+export function getActivePublicKey() {
+    const wallet = getWallet();
+    return wallet.n;
+}
+
 export async function uploadRepo(zipBuffer: Buffer, tags: Tag[]) {
     try {
         // upload compressed repo using turbo

--- a/src/lib/privateRepo.ts
+++ b/src/lib/privateRepo.ts
@@ -1,0 +1,104 @@
+import Arweave from 'arweave';
+import crypto from 'crypto';
+import { getActivePublicKey } from './arweaveHelper';
+import { getWallet } from './common';
+
+type PrivateState = {
+    iv: string;
+    encKeys: Record<string, string>;
+    version: string;
+    pubKeys: string[];
+};
+
+const arweave = new Arweave({
+    host: 'ar-io.net',
+    port: 443,
+    protocol: 'https',
+});
+
+async function deriveAddress(publicKey: string) {
+    const pubKeyBuf = arweave.utils.b64UrlToBuffer(publicKey);
+    const sha512DigestBuf = await crypto.subtle.digest('SHA-512', pubKeyBuf);
+
+    return arweave.utils.bufferTob64Url(new Uint8Array(sha512DigestBuf));
+}
+
+async function encryptDataWithExistingKey(
+    file: ArrayBuffer,
+    aesKey: any,
+    iv: Uint8Array
+) {
+    let key = aesKey;
+
+    if (!(aesKey instanceof crypto.webcrypto.CryptoKey)) {
+        key = await crypto.subtle.importKey(
+            'raw',
+            aesKey,
+            { name: 'AES-GCM', length: 256 },
+            true,
+            ['encrypt']
+        );
+    }
+
+    const encrypted = await crypto.subtle.encrypt(
+        { name: 'AES-GCM', iv: iv },
+        key,
+        file
+    );
+
+    return encrypted;
+}
+
+async function decryptAesKeyWithPrivateKey(encryptedAesKey: Uint8Array) {
+    const privateKey = getWallet();
+    const key = await crypto.subtle.importKey(
+        'jwk',
+        privateKey,
+        {
+            name: 'RSA-OAEP',
+            hash: 'SHA-256',
+        },
+        false,
+        ['decrypt']
+    );
+
+    const options = {
+        name: 'RSA-OAEP',
+        hash: 'SHA-256',
+    };
+
+    const decryptedAesKey = await crypto.subtle.decrypt(
+        options,
+        key,
+        encryptedAesKey
+    );
+
+    return new Uint8Array(decryptedAesKey);
+}
+
+export async function encryptRepo(
+    repoArrayBuf: ArrayBuffer,
+    privateStateTxId: string
+) {
+    const pubKey = getActivePublicKey();
+    const address = await deriveAddress(pubKey);
+
+    const response = await fetch(`https://arweave.net/${privateStateTxId}`);
+    const privateState = (await response.json()) as PrivateState;
+
+    const encAesKeyStr = privateState.encKeys[address]!;
+    const encAesKeyBuf = arweave.utils.b64UrlToBuffer(encAesKeyStr);
+
+    const aesKey = (await decryptAesKeyWithPrivateKey(
+        encAesKeyBuf
+    )) as unknown as ArrayBuffer;
+    const ivArrBuff = arweave.utils.b64UrlToBuffer(privateState.iv);
+
+    const encryptedRepo = await encryptDataWithExistingKey(
+        repoArrayBuf,
+        aesKey,
+        ivArrBuff
+    );
+
+    return Buffer.from(encryptedRepo);
+}

--- a/src/lib/warpHelper.ts
+++ b/src/lib/warpHelper.ts
@@ -1,5 +1,4 @@
 import { WarpFactory, defaultCacheOptions } from 'warp-contracts';
-import { v4 as uuidv4 } from 'uuid';
 import {
     getDescription,
     getTitle,
@@ -37,6 +36,7 @@ export async function getRepos() {
 
 export async function postRepoToWarp(
     dataTxId: string,
+    repoId: string,
     repoInfo?: { id: string } | undefined
 ) {
     if (repoInfo) {
@@ -69,7 +69,7 @@ export async function postRepoToWarp(
         }
     } else {
         try {
-            const result = await newRepo(dataTxId);
+            const result = await newRepo(repoId, dataTxId);
             await trackAmplitudeAnalyticsEvent(
                 'Repository',
                 'Successfully created a repo',
@@ -91,14 +91,12 @@ export async function postRepoToWarp(
     }
 }
 
-async function newRepo(dataTxId: string) {
+async function newRepo(repoId: string, dataTxId: string) {
     if (!title || !dataTxId) throw '[ warp ] No title or dataTx for new repo';
 
     // const contract = getWarp().contract(contractTxId).connect(jwk);
 
-    const uuid = uuidv4();
-
-    const payload = { id: uuid, name: title, description, dataTxId };
+    const payload = { id: repoId, name: title, description, dataTxId };
 
     await waitFor(500);
 
@@ -108,9 +106,9 @@ async function newRepo(dataTxId: string) {
         payload,
     });
 
-    console.log(`[ warp ] Repo '${title}' initialized with id '${uuid}'`);
+    console.log(`[ warp ] Repo '${title}' initialized with id '${repoId}'`);
 
-    return { id: uuid };
+    return { id: repoId };
 }
 
 async function updateRepo(id: string, dataTxId: string) {

--- a/src/lib/warpHelper.ts
+++ b/src/lib/warpHelper.ts
@@ -31,7 +31,12 @@ export async function getRepos() {
             owner: address,
         },
     });
-    return response.result as { id: string; name: string }[];
+    return response.result as {
+        id: string;
+        name: string;
+        private: boolean;
+        privateStateTxId: string;
+    }[];
 }
 
 export async function postRepoToWarp(


### PR DESCRIPTION
## Summary

This PR addresses the recent update in the Protocol Land (PL) repository.

- Add support for modified zip folder structure. The previous zip format contained a `/repo-name` directory, while the updated version now contains a `/repo-id` directory. 

- It also adds support for private repo.

Related issues: [labscommunity/protocol-land#40](https://github.com/labscommunity/protocol-land/pull/40) https://github.com/labscommunity/protocol-land/pull/39